### PR TITLE
Some fixes at the examples, package installation and CircleCI build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Introduction
 
+[![Build Status](https://img.shields.io/circleci/project/ideoforms/isobar/master.svg)](https://circleci.com/gh/ideoforms/isobar)
+
+
 isobar is a Python library for expressing and constructing musical patterns, designed for use in algorithmic composition. It allows for concise construction, manipulation and transposition of sequences, supporting scalar operations on lazy patterns.
 
 Output can be sent via MIDI, OSC or SocketIO, or written to a .mid file. Input (for interactive systems) can be taken via MIDI, and patterns can be read from a .mid file.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+## Customize dependencies
+dependencies:
+  pre:
+    - sudo apt-get update; sudo apt-get install libjack-dev 
+
+## Customize test commands
+test:
+  override:
+    - python setup.py install 
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 ## Customize dependencies
 dependencies:
   pre:
-    - sudo apt-get update; sudo apt-get install libjack-dev 
+    - sudo apt-get update; sudo apt-get install libjack0; sudo apt-get install libjack-dev 
 
 ## Customize test commands
 test:

--- a/examples/ex-basics.py
+++ b/examples/ex-basics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from isobar import *
 

--- a/examples/ex-euclidean.py
+++ b/examples/ex-euclidean.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #------------------------------------------------------------------------
 # Simple example of three parallel voices based on the Euclidean

--- a/examples/ex-lsystem-grapher.py
+++ b/examples/ex-lsystem-grapher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # example-lsystem-grapher:
 # generates an l-system and its ASCII representation

--- a/examples/ex-lsystem-rhythm.py
+++ b/examples/ex-lsystem-rhythm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # test-plsys-rhythm:
 # generates a rhythm line based on an l-system sprouting structure,

--- a/examples/ex-lsystem-stochastic.py
+++ b/examples/ex-lsystem-stochastic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # example-lsystem-stochastic:
 # generates a stochastic l-system arpeggio
@@ -10,7 +10,7 @@ from isobar.io.midi import *
 import random
 import time
 
-notes = PLSys("N[+N--?N]+N[+?N]", depth = 4) 
+notes = PLSys("N[+N--?N]+N[+?N]", depth = 4)
 notes = PDegree(notes, Scale.majorPenta)
 notes = notes % 36 + 52
 

--- a/examples/ex-markov-learner.py
+++ b/examples/ex-markov-learner.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # parallel markov chain learner:
 # 1. takes MIDI input, and constructs three markov chains for pitch, duration
-#    and amplitude. 
+#    and amplitude.
 # 2. after receiving a low "C", plays back melodies which are statistically
 #    similar to the input.
 # after francois pachet's "continuator".

--- a/examples/ex-markov-learner.py
+++ b/examples/ex-markov-learner.py
@@ -15,7 +15,7 @@ import time
 m_in  = MidiIn()
 m_out = MidiOut()
 
-learner = MarkovLParallel(3)
+learner = MarkovParallelLearners(3)
 clock0 = 0
 
 while True:

--- a/examples/ex-midifile-write.py
+++ b/examples/ex-midifile-write.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 
 # ex-midifile-write:
 # Simple example of writing to a MIDI file in real time.

--- a/examples/ex-permut-degree.py
+++ b/examples/ex-permut-degree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # import vital classes from isobar namespace
 from isobar import *
@@ -15,7 +15,7 @@ pdur = PShuffle([ 1, 1, 2, 2, 4 ], 1)
 pdur  = PPermut(pdur) * 0.25
 
 pamp = PShuffle([ 10, 15, 20, 35 ], 2)
-pamp = PPermut(pamp) 
+pamp = PPermut(pamp)
 
 # schedule on a 60bpm timeline and send to MIDI output
 timeline = Timeline(60)

--- a/examples/ex-piano-phase.py
+++ b/examples/ex-piano-phase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # implementation of steve reich's "piano phase" (1967):
 # two identical piano lines, one with a slightly longer duration,

--- a/examples/ex-subsequence.py
+++ b/examples/ex-subsequence.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from isobar import *
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 #------------------------------------------------------------------------
 # Generate a PyPI-friendly RST file from our markdown README.
@@ -19,7 +19,7 @@ setup(
 	author = 'Daniel Jones',
 	author_email = 'dan-isobar@erase.net',
 	url = 'https://github.com/ideoforms/isobar',
-	packages = ['isobar'],
+	packages = find_packages(exclude=['examples']),
 	install_requires = ['pyOSC >= 0.3b0', 'python-rtmidi'],
 	keywords = ('sound', 'music', 'composition'),
 	classifiers = [


### PR DESCRIPTION
- Fixed examples hashbang (to work with virtualenv)
- Fixed setup.py installation (some examples weren't working after installation)
- Inserting CircleCI Build Status badge at the README file
- Inserted a CircleCI build configuration file, to install libjack and only run `python setup.py install` as test (we can insert more tests later)
