### PR TITLE
Fix python-osc dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author_email = 'dan-isobar@erase.net',
     url = 'https://github.com/ideoforms/isobar',
     packages = find_packages(),
-    install_requires = ['pythonosc', 'python-rtmidi', 'midiutil'],
+    install_requires = ['python-osc', 'python-rtmidi', 'midiutil'],
     keywords = ('sound', 'music', 'composition'),
     classifiers = [
         'Topic :: Multimedia :: Sound/Audio',


### PR DESCRIPTION
Fixed a small typo in setup.py that caused to fail to build from source.
(the module is called `pythonosc` but in pypi `python-osc` :man_shrugging:)  