### PR TITLE
Added Copy to Pattern Args

### DIFF
--- a/isobar/pattern/core.py
+++ b/isobar/pattern/core.py
@@ -472,7 +472,7 @@ class PAbs(Pattern):
     """ PAbs: Absolute value of `input` """
 
     def __init__(self, input):
-        self.input = input
+        self.input = copy.copy(input)
 
     def __next__(self):
         next = Pattern.value(self.input)
@@ -484,7 +484,7 @@ class PInt(Pattern):
     """ PInt: Integer value of `input` """
 
     def __init__(self, input):
-        self.input = input
+        self.input = copy.copy(input)
 
     def __next__(self):
         next = Pattern.value(self.input)

--- a/isobar/pattern/scalar.py
+++ b/isobar/pattern/scalar.py
@@ -1,3 +1,5 @@
+import copy
+
 from .core import Pattern
 from .sequence import PSeries
 from ..util import scale_lin_exp, scale_lin_lin
@@ -39,7 +41,7 @@ class PDiff(Pattern):
         """
 
     def __init__(self, source):
-        self.source = source
+        self.source = copy.copy(source)
         self.current = Pattern.value(self.source)
 
     def reset(self):
@@ -60,7 +62,7 @@ class PSkipIf(Pattern):
         """
 
     def __init__(self, pattern, skip):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.skip = skip
 
     def __next__(self):
@@ -78,7 +80,7 @@ class PNormalise(Pattern):
         """
 
     def __init__(self, input):
-        self.input = input
+        self.input = copy.copy(input)
 
         self.lower = None
         self.upper = None
@@ -117,7 +119,7 @@ class PMap(Pattern):
         """
 
     def __init__(self, input, operator, *args, **kwargs):
-        self.input = input
+        self.input = copy.copy(input)
         self.operator = operator
         self.args = args
         self.kwargs = kwargs

--- a/isobar/pattern/sequence.py
+++ b/isobar/pattern/sequence.py
@@ -198,7 +198,7 @@ class PLoop(Pattern):
         """
 
     def __init__(self, pattern, count=sys.maxsize):
-        self.pattern = pattern
+        self.pattern = copy(pattern)
         self.count = count
         self.pos = 0
         self.loop_index = 0
@@ -240,7 +240,7 @@ class PPingPong(Pattern):
         """
 
     def __init__(self, pattern, count=1):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.count = count
         self.reset()
 
@@ -275,7 +275,7 @@ class PCreep(Pattern):
         """
 
     def __init__(self, pattern, length=4, creep=1, repeats=1, prob=1):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.length = length
         self.creep = creep
         self.repeats = repeats
@@ -341,7 +341,7 @@ class PStutter(Pattern):
         """
 
     def __init__(self, pattern, count=2):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.count = count
         self.count_current = 0
         self.pos = 0
@@ -363,7 +363,7 @@ class PSubsequence(Pattern):
         """
 
     def __init__(self, pattern, offset, length):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.offset = offset
         self.length = length
         self.pos = 0
@@ -390,7 +390,7 @@ class PSubsequence(Pattern):
 
 class PInterpolate(Pattern):
     def __init__(self, pattern, steps, interpolation=INTERPOLATION_LINEAR):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.steps = steps
         self.interpolation = interpolation
         self.reset()
@@ -457,7 +457,7 @@ class PReset(Pattern):
         """
 
     def __init__(self, pattern, trigger):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.trigger = trigger
 
     def __next__(self):
@@ -521,7 +521,7 @@ class PPad(Pattern):
         """
 
     def __init__(self, pattern, length):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.length = length
         self.reset()
 
@@ -548,7 +548,7 @@ class PPadToMultiple(Pattern):
         """
 
     def __init__(self, pattern, multiple, minimum_pad=0):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.multiple = multiple
         self.minimum_pad = minimum_pad
         self.count = 0

--- a/isobar/pattern/static.py
+++ b/isobar/pattern/static.py
@@ -1,3 +1,5 @@
+import copy
+
 from . import Pattern
 
 class Globals:
@@ -65,7 +67,7 @@ class PGlobals (Pattern):
 
 class PStaticPattern(Pattern):
     def __init__(self, pattern, element_duration):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.value = None
         self.element_duration = element_duration
         self.current_element_start_time = None

--- a/isobar/pattern/tonal.py
+++ b/isobar/pattern/tonal.py
@@ -1,3 +1,5 @@
+import copy
+
 from .core import Pattern
 from ..scale import Scale
 from ..util import midi_note_to_frequency
@@ -38,7 +40,7 @@ class PFilterByKey(Pattern):
         """
 
     def __init__(self, pattern, key):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.key = key
 
     def __next__(self):
@@ -57,7 +59,7 @@ class PNearestNoteInKey(Pattern):
         [0, 0, 2, 2, 4, 5, 5, 7, 7, 9, 9, 11, 12, 12, 14, 14]
         """
     def __init__(self, pattern, key):
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.key = key
 
     def __next__(self):

--- a/isobar/pattern/warp.py
+++ b/isobar/pattern/warp.py
@@ -1,3 +1,5 @@
+import copy
+
 from .core import Pattern
 
 import math
@@ -16,7 +18,7 @@ class PWInterpolate(PWarp):
 
     def __init__(self, pattern, length=1):
         self.length = length
-        self.pattern = pattern
+        self.pattern = copy.copy(pattern)
         self.pos = self.length
         self.value = 0.0
         self.dv = 0.0


### PR DESCRIPTION
As seen in Issue #26, there's are some issues with passing patterns by reference instead of by value. When using the original and passed pattern, values get divided between the two. I went through the pattern files and looked for any pattern arguments, using the `copy` library to do a shallow copy of each pattern so the original pattern will not be affected. 

Other than `PRef`, this was a pretty broad change as most things seemed like they would benefit a shallow copy, so if any should be kept as a deep copy let me know.