### PR TITLE
Docs: Minor fixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,14 +20,15 @@ isobar does not generate any audio on its own. It must be configured to send eve
 
 There are a few key components in isobar.
 
-- The **[Timeline](timelines/index.md)** handles timing and scheduling, triggering events at the correct moment. It is made up of multiple Tracks, which normally . It can maintain its own clock with millisecond accuracy, or sync to an external clock.  
+- The **[Timeline](timelines/index.md)** handles timing and scheduling, triggering events at the correct moment. It can maintain its own clock with millisecond accuracy, or sync to an external clock.  
 - **[Events](events/index.md)** correspond to triggers that are typically sent to output devices or received from input devices. These may be MIDI notes, control changes, OSC triggers, and other general types. An event is typically described by a dict with a number of properties. For example: `{ "note" : 60, "amplitude": 127 }`
 - **[Patterns](patterns/index.md)**: Each of the properties of an event can be specified by a Pattern, which generates a sequence of return values. Simple pattern types generate fixed sequences, random values, or values based on statistical models. Patterns can be passed other patterns as parameters, so they can operate on each other -- for example, causing an input pattern to loop N times, or skipping the input values with some probability.  
 - **[Devices](devices/index.md)**: Events are sent to output devices, over interfaces such as MIDI or OSC. Events can also be received and processed. 
 
 ### Flow diagram
 
-![Flow Diagram](diagrams/Isobar Flow Diagram.png)
+<a href="diagrams/Isobar Flow Diagram.png" target="_blank"><img src="diagrams/Isobar Flow Diagram.png" alt="A flow diagram showing an overview isobar" rel="noopener noreferrer"/></a>
+
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ There are a few key components in isobar.
 
 ### Flow diagram
 
-<a href="diagrams/Isobar Flow Diagram.png" target="_blank"><img src="diagrams/Isobar Flow Diagram.png" alt="A flow diagram showing an overview isobar" rel="noopener noreferrer"/></a>
+<a href="diagrams/Isobar Flow Diagram.png" target="_blank"><img src="diagrams/Isobar Flow Diagram.png" alt="A flow diagram showing an overview of isobar" rel="noopener noreferrer"/></a>
 
 
 ## Documentation

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -29,7 +29,7 @@ By assigning patterns to properties of [events](/events/), you can specify seque
 
 Patterns can be finite, such as the example above, or infinite, in which case they will keep generating new values forever.
 
-Patterns can also typically generate different Python types. Some Pattern classes will seek to do the right thing based on whether they are passed them int or float arguments.
+Patterns can also typically generate different Python types. Some Pattern classes will seek to do the right thing based on whether they are passed int or float arguments.
 
  - `PSequence([ "apple", "pear" ])` generates an alternating pair of strings
  - `PWhite(0, 10)` generates a stream of ints between `[0 .. 9]`


### PR DESCRIPTION
Fixed typos in docs/index and docs/patterns/index. Added inline HTML to enable user to click on isobar flow diagram and open it larger in a new tab.